### PR TITLE
Add new field to all database tables

### DIFF
--- a/DATABASE_FIELD_MANAGEMENT.md
+++ b/DATABASE_FIELD_MANAGEMENT.md
@@ -1,0 +1,200 @@
+# 数据库表字段管理工具
+
+这个工具提供了使用Java为数据库的各张表批量添加字段的功能。
+
+## 功能特性
+
+- ✅ 支持MySQL和PostgreSQL数据库
+- ✅ 批量为所有表添加字段
+- ✅ 为指定表添加字段
+- ✅ 添加常用字段（创建时间、更新时间、版本号、软删除标记）
+- ✅ 检查字段是否已存在，避免重复添加
+- ✅ 提供REST API和命令行工具两种使用方式
+- ✅ 完整的日志记录和错误处理
+
+## 配置说明
+
+### 1. 数据库配置
+
+在 `src/main/resources/application.yml` 中配置数据库连接信息：
+
+```yaml
+spring:
+  datasource:
+    # MySQL配置
+    url: jdbc:mysql://localhost:3306/your_database?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai
+    username: your_username
+    password: your_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    
+    # 或者 PostgreSQL配置
+    # url: jdbc:postgresql://localhost:5432/your_database
+    # username: your_username
+    # password: your_password
+    # driver-class-name: org.postgresql.Driver
+```
+
+### 2. Maven依赖
+
+项目已包含必要的依赖：
+- MySQL/PostgreSQL JDBC驱动
+- HikariCP连接池
+- Spring JDBC
+
+## 使用方式
+
+### 方式1：REST API
+
+启动Spring Boot应用后，可以通过以下API端点操作：
+
+#### 查看所有表
+```
+GET /api/database/schema/tables
+```
+
+#### 为所有表添加字段
+```
+POST /api/database/schema/add-field/all
+Content-Type: application/json
+
+{
+    "fieldName": "remark",
+    "fieldType": "VARCHAR(500)",
+    "nullable": true,
+    "defaultValue": null
+}
+```
+
+#### 为指定表添加字段
+```
+POST /api/database/schema/add-field/specific
+Content-Type: application/json
+
+{
+    "tableNames": ["users", "orders", "products"],
+    "fieldName": "status",
+    "fieldType": "INT",
+    "nullable": false,
+    "defaultValue": "1"
+}
+```
+
+#### 添加常用字段
+```
+POST /api/database/schema/add-common-fields
+```
+
+### 方式2：命令行工具
+
+运行命令行工具：
+
+```bash
+java -cp target/classes:target/lib/* com.example.wechatpay.util.DatabaseFieldAdder
+```
+
+工具提供交互式菜单，可以：
+1. 查看所有表
+2. 为所有表添加单个字段
+3. 为所有表添加常用字段
+4. 为指定表添加字段
+5. 检查字段是否存在
+
+### 方式3：编程方式
+
+```java
+@Autowired
+private DatabaseSchemaService databaseSchemaService;
+
+// 为所有表添加字段
+SchemaUpdateResult result = databaseSchemaService.addFieldToAllTables(
+    "remark", "VARCHAR(500)", true, null
+);
+
+// 为所有表添加常用字段
+Map<String, SchemaUpdateResult> results = databaseSchemaService.addCommonFieldsToAllTables();
+
+// 为指定表添加字段
+List<String> tables = Arrays.asList("users", "orders");
+SchemaUpdateResult result = databaseSchemaService.addFieldToSpecificTables(
+    tables, "status", "INT", false, "1"
+);
+```
+
+## 常用字段说明
+
+工具预定义了一些常用字段：
+
+| 字段名 | 类型 | 说明 | 默认值 |
+|--------|------|------|--------|
+| created_at | TIMESTAMP | 创建时间 | CURRENT_TIMESTAMP |
+| updated_at | TIMESTAMP | 更新时间 | CURRENT_TIMESTAMP (MySQL支持ON UPDATE) |
+| version | INT | 版本号(乐观锁) | 0 |
+| deleted | TINYINT(1) | 软删除标记 | 0 |
+
+## 支持的数据类型
+
+### MySQL
+- `VARCHAR(n)` - 变长字符串
+- `CHAR(n)` - 定长字符串
+- `TEXT` - 长文本
+- `INT` - 整数
+- `BIGINT` - 长整数
+- `DECIMAL(p,s)` - 精确数值
+- `TIMESTAMP` - 时间戳
+- `DATETIME` - 日期时间
+- `DATE` - 日期
+- `TINYINT(1)` - 布尔值
+
+### PostgreSQL
+- `VARCHAR(n)` - 变长字符串
+- `CHAR(n)` - 定长字符串
+- `TEXT` - 长文本
+- `INTEGER` - 整数
+- `BIGINT` - 长整数
+- `NUMERIC(p,s)` - 精确数值
+- `TIMESTAMP` - 时间戳
+- `DATE` - 日期
+- `BOOLEAN` - 布尔值
+
+## 安全注意事项
+
+1. **备份数据库**: 在执行任何表结构修改前，请务必备份数据库
+2. **测试环境**: 建议先在测试环境验证
+3. **权限检查**: 确保数据库用户有ALTER TABLE权限
+4. **字段命名**: 遵循数据库命名规范
+5. **数据类型**: 根据实际需求选择合适的数据类型
+
+## 错误处理
+
+- 工具会自动检查字段是否已存在，避免重复添加
+- 每个表的操作都是独立的，单个表失败不会影响其他表
+- 提供详细的日志记录，便于问题排查
+- 操作结果包含成功和失败的表列表
+
+## 示例场景
+
+### 场景1：为所有表添加审计字段
+```java
+// 添加创建时间和更新时间
+databaseSchemaService.addCreatedAtToAllTables();
+databaseSchemaService.addUpdatedAtToAllTables();
+```
+
+### 场景2：为用户相关表添加状态字段
+```java
+List<String> userTables = Arrays.asList("users", "user_profiles", "user_settings");
+databaseSchemaService.addFieldToSpecificTables(userTables, "status", "INT", false, "1");
+```
+
+### 场景3：为所有表添加软删除支持
+```java
+databaseSchemaService.addSoftDeleteToAllTables();
+```
+
+## 注意事项
+
+1. 确保数据库连接配置正确
+2. 执行前请备份重要数据
+3. 大型数据库操作可能需要较长时间
+4. 某些字段类型在不同数据库中可能有差异
+5. 建议在维护窗口期间执行批量操作

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,35 @@
             <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- 数据库相关依赖 -->
+        <!-- JDBC驱动 - MySQL -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+        
+        <!-- JDBC驱动 - PostgreSQL -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.6.0</version>
+        </dependency>
+        
+        <!-- 数据库连接池 - HikariCP -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        
+        <!-- Spring JDBC -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>5.3.21</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/run_field_adder.sh
+++ b/run_field_adder.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# 数据库字段添加工具启动脚本
+
+echo "=== 数据库表字段添加工具 ==="
+echo "正在编译项目..."
+
+# 编译项目
+mvn clean compile -q
+
+if [ $? -eq 0 ]; then
+    echo "编译成功，启动字段添加工具..."
+    echo "注意：请确保已在 application.yml 中正确配置数据库连接信息"
+    echo ""
+    
+    # 运行命令行工具
+    java -cp "target/classes:$(mvn dependency:build-classpath -q -Dmdep.outputFile=/dev/stdout)" \
+         com.example.wechatpay.util.DatabaseFieldAdder
+else
+    echo "编译失败，请检查代码是否有错误"
+    exit 1
+fi

--- a/src/main/java/com/example/wechatpay/config/DatabaseConfig.java
+++ b/src/main/java/com/example/wechatpay/config/DatabaseConfig.java
@@ -1,0 +1,76 @@
+package com.example.wechatpay.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * 数据库配置类
+ * 配置数据源和JdbcTemplate
+ */
+@Configuration
+public class DatabaseConfig {
+
+    @Value("${spring.datasource.url}")
+    private String jdbcUrl;
+
+    @Value("${spring.datasource.username}")
+    private String username;
+
+    @Value("${spring.datasource.password}")
+    private String password;
+
+    @Value("${spring.datasource.driver-class-name}")
+    private String driverClassName;
+
+    @Value("${spring.datasource.hikari.maximum-pool-size:20}")
+    private int maximumPoolSize;
+
+    @Value("${spring.datasource.hikari.minimum-idle:5}")
+    private int minimumIdle;
+
+    @Value("${spring.datasource.hikari.connection-timeout:30000}")
+    private long connectionTimeout;
+
+    @Value("${spring.datasource.hikari.idle-timeout:600000}")
+    private long idleTimeout;
+
+    @Value("${spring.datasource.hikari.max-lifetime:1800000}")
+    private long maxLifetime;
+
+    /**
+     * 配置数据源
+     */
+    @Bean
+    public DataSource dataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(jdbcUrl);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setDriverClassName(driverClassName);
+        config.setMaximumPoolSize(maximumPoolSize);
+        config.setMinimumIdle(minimumIdle);
+        config.setConnectionTimeout(connectionTimeout);
+        config.setIdleTimeout(idleTimeout);
+        config.setMaxLifetime(maxLifetime);
+        
+        // 连接池优化配置
+        config.setLeakDetectionThreshold(60000);
+        config.setPoolName("HikariPool-Database");
+        
+        return new HikariDataSource(config);
+    }
+
+    /**
+     * 配置JdbcTemplate
+     */
+    @Bean
+    public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+}

--- a/src/main/java/com/example/wechatpay/controller/DatabaseSchemaController.java
+++ b/src/main/java/com/example/wechatpay/controller/DatabaseSchemaController.java
@@ -1,0 +1,217 @@
+package com.example.wechatpay.controller;
+
+import com.example.wechatpay.service.DatabaseSchemaService;
+import com.example.wechatpay.util.DatabaseSchemaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 数据库表结构管理控制器
+ * 提供REST API来管理数据库表字段
+ */
+@RestController
+@RequestMapping("/api/database/schema")
+public class DatabaseSchemaController {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSchemaController.class);
+
+    @Autowired
+    private DatabaseSchemaService databaseSchemaService;
+
+    @Autowired
+    private DatabaseSchemaUtils databaseSchemaUtils;
+
+    /**
+     * 获取所有表名
+     */
+    @GetMapping("/tables")
+    public ResponseEntity<List<String>> getAllTables() {
+        try {
+            List<String> tables = databaseSchemaUtils.getAllTableNames();
+            return ResponseEntity.ok(tables);
+        } catch (Exception e) {
+            logger.error("获取表名失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 获取所有表的详细信息
+     */
+    @GetMapping("/tables/info")
+    public ResponseEntity<List<DatabaseSchemaService.TableInfo>> getAllTablesInfo() {
+        try {
+            List<DatabaseSchemaService.TableInfo> tablesInfo = databaseSchemaService.getAllTablesInfo();
+            return ResponseEntity.ok(tablesInfo);
+        } catch (Exception e) {
+            logger.error("获取表信息失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 为所有表添加字段
+     */
+    @PostMapping("/add-field/all")
+    public ResponseEntity<DatabaseSchemaService.SchemaUpdateResult> addFieldToAllTables(@RequestBody AddFieldRequest request) {
+        try {
+            logger.info("收到为所有表添加字段的请求: {}", request);
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToAllTables(
+                    request.getFieldName(),
+                    request.getFieldType(),
+                    request.isNullable(),
+                    request.getDefaultValue()
+            );
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            logger.error("为所有表添加字段失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 为指定表添加字段
+     */
+    @PostMapping("/add-field/specific")
+    public ResponseEntity<DatabaseSchemaService.SchemaUpdateResult> addFieldToSpecificTables(@RequestBody AddFieldToTablesRequest request) {
+        try {
+            logger.info("收到为指定表添加字段的请求: {}", request);
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToSpecificTables(
+                    request.getTableNames(),
+                    request.getFieldName(),
+                    request.getFieldType(),
+                    request.isNullable(),
+                    request.getDefaultValue()
+            );
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            logger.error("为指定表添加字段失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 为所有表添加常用字段（created_at, updated_at, version, deleted）
+     */
+    @PostMapping("/add-common-fields")
+    public ResponseEntity<Map<String, DatabaseSchemaService.SchemaUpdateResult>> addCommonFieldsToAllTables() {
+        try {
+            logger.info("收到为所有表添加常用字段的请求");
+            Map<String, DatabaseSchemaService.SchemaUpdateResult> results = databaseSchemaService.addCommonFieldsToAllTables();
+            return ResponseEntity.ok(results);
+        } catch (Exception e) {
+            logger.error("为所有表添加常用字段失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 为所有表添加创建时间字段
+     */
+    @PostMapping("/add-created-at")
+    public ResponseEntity<DatabaseSchemaService.SchemaUpdateResult> addCreatedAtToAllTables() {
+        try {
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addCreatedAtToAllTables();
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            logger.error("为所有表添加创建时间字段失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 为所有表添加更新时间字段
+     */
+    @PostMapping("/add-updated-at")
+    public ResponseEntity<DatabaseSchemaService.SchemaUpdateResult> addUpdatedAtToAllTables() {
+        try {
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addUpdatedAtToAllTables();
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            logger.error("为所有表添加更新时间字段失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 检查字段是否存在
+     */
+    @GetMapping("/check-field/{tableName}/{fieldName}")
+    public ResponseEntity<Boolean> checkFieldExists(@PathVariable String tableName, @PathVariable String fieldName) {
+        try {
+            boolean exists = databaseSchemaUtils.columnExists(tableName, fieldName);
+            return ResponseEntity.ok(exists);
+        } catch (Exception e) {
+            logger.error("检查字段是否存在失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    /**
+     * 添加字段请求类
+     */
+    public static class AddFieldRequest {
+        private String fieldName;
+        private String fieldType;
+        private boolean nullable = true;
+        private String defaultValue;
+
+        // Constructors
+        public AddFieldRequest() {}
+
+        public AddFieldRequest(String fieldName, String fieldType, boolean nullable, String defaultValue) {
+            this.fieldName = fieldName;
+            this.fieldType = fieldType;
+            this.nullable = nullable;
+            this.defaultValue = defaultValue;
+        }
+
+        // Getters and Setters
+        public String getFieldName() { return fieldName; }
+        public void setFieldName(String fieldName) { this.fieldName = fieldName; }
+        public String getFieldType() { return fieldType; }
+        public void setFieldType(String fieldType) { this.fieldType = fieldType; }
+        public boolean isNullable() { return nullable; }
+        public void setNullable(boolean nullable) { this.nullable = nullable; }
+        public String getDefaultValue() { return defaultValue; }
+        public void setDefaultValue(String defaultValue) { this.defaultValue = defaultValue; }
+
+        @Override
+        public String toString() {
+            return String.format("AddFieldRequest{fieldName='%s', fieldType='%s', nullable=%s, defaultValue='%s'}",
+                    fieldName, fieldType, nullable, defaultValue);
+        }
+    }
+
+    /**
+     * 为指定表添加字段请求类
+     */
+    public static class AddFieldToTablesRequest extends AddFieldRequest {
+        private List<String> tableNames;
+
+        // Constructors
+        public AddFieldToTablesRequest() {}
+
+        public AddFieldToTablesRequest(List<String> tableNames, String fieldName, String fieldType, boolean nullable, String defaultValue) {
+            super(fieldName, fieldType, nullable, defaultValue);
+            this.tableNames = tableNames;
+        }
+
+        // Getters and Setters
+        public List<String> getTableNames() { return tableNames; }
+        public void setTableNames(List<String> tableNames) { this.tableNames = tableNames; }
+
+        @Override
+        public String toString() {
+            return String.format("AddFieldToTablesRequest{tableNames=%s, fieldName='%s', fieldType='%s', nullable=%s, defaultValue='%s'}",
+                    tableNames, getFieldName(), getFieldType(), isNullable(), getDefaultValue());
+        }
+    }
+}

--- a/src/main/java/com/example/wechatpay/example/DatabaseSchemaExample.java
+++ b/src/main/java/com/example/wechatpay/example/DatabaseSchemaExample.java
@@ -1,0 +1,202 @@
+package com.example.wechatpay.example;
+
+import com.example.wechatpay.service.DatabaseSchemaService;
+import com.example.wechatpay.util.DatabaseSchemaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 数据库表字段添加示例
+ * 演示如何使用DatabaseSchemaService为数据库表添加字段
+ */
+@Component
+public class DatabaseSchemaExample implements CommandLineRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSchemaExample.class);
+
+    @Autowired
+    private DatabaseSchemaService databaseSchemaService;
+
+    @Autowired
+    private DatabaseSchemaUtils databaseSchemaUtils;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // 注意：这个示例默认不会自动运行，需要手动调用
+        // runExamples();
+    }
+
+    /**
+     * 运行所有示例
+     */
+    public void runExamples() {
+        logger.info("=== 数据库表字段管理示例开始 ===");
+        
+        try {
+            // 示例1：查看所有表
+            example1_showAllTables();
+            
+            // 示例2：为所有表添加单个字段
+            example2_addSingleFieldToAllTables();
+            
+            // 示例3：为指定表添加字段
+            example3_addFieldToSpecificTables();
+            
+            // 示例4：为所有表添加常用字段
+            example4_addCommonFields();
+            
+            // 示例5：检查字段是否存在
+            example5_checkFieldExists();
+            
+        } catch (Exception e) {
+            logger.error("示例执行失败: {}", e.getMessage(), e);
+        }
+        
+        logger.info("=== 数据库表字段管理示例结束 ===");
+    }
+
+    /**
+     * 示例1：查看所有表
+     */
+    private void example1_showAllTables() {
+        logger.info("\n--- 示例1：查看所有表 ---");
+        
+        try {
+            List<String> tableNames = databaseSchemaUtils.getAllTableNames();
+            logger.info("数据库中共有 {} 个表:", tableNames.size());
+            for (String tableName : tableNames) {
+                logger.info("  - {}", tableName);
+            }
+
+            // 获取表的详细信息
+            List<DatabaseSchemaService.TableInfo> tablesInfo = databaseSchemaService.getAllTablesInfo();
+            logger.info("\n表详细信息:");
+            for (DatabaseSchemaService.TableInfo tableInfo : tablesInfo) {
+                logger.info("  表: {} ({}列)", tableInfo.getTableName(), tableInfo.getColumnCount());
+            }
+        } catch (Exception e) {
+            logger.error("查看表信息失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 示例2：为所有表添加单个字段
+     */
+    private void example2_addSingleFieldToAllTables() {
+        logger.info("\n--- 示例2：为所有表添加单个字段 ---");
+        
+        try {
+            // 为所有表添加一个备注字段
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToAllTables(
+                    "remark", 
+                    "VARCHAR(500)", 
+                    true, 
+                    null
+            );
+            
+            logger.info("添加字段结果: {}", result);
+            logger.info("成功的表: {}", result.getSuccessTables());
+            if (!result.getFailureTables().isEmpty()) {
+                logger.warn("失败的表: {}", result.getFailureTables());
+            }
+        } catch (Exception e) {
+            logger.error("为所有表添加字段失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 示例3：为指定表添加字段
+     */
+    private void example3_addFieldToSpecificTables() {
+        logger.info("\n--- 示例3：为指定表添加字段 ---");
+        
+        try {
+            // 假设我们只想为特定的表添加字段
+            List<String> targetTables = Arrays.asList("users", "orders", "products");
+            
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToSpecificTables(
+                    targetTables,
+                    "status", 
+                    "INT", 
+                    false, 
+                    "1"
+            );
+            
+            logger.info("为指定表添加字段结果: {}", result);
+            logger.info("成功的表: {}", result.getSuccessTables());
+            if (!result.getFailureTables().isEmpty()) {
+                logger.warn("失败的表: {}", result.getFailureTables());
+            }
+        } catch (Exception e) {
+            logger.error("为指定表添加字段失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 示例4：为所有表添加常用字段
+     */
+    private void example4_addCommonFields() {
+        logger.info("\n--- 示例4：为所有表添加常用字段 ---");
+        
+        try {
+            Map<String, DatabaseSchemaService.SchemaUpdateResult> results = databaseSchemaService.addCommonFieldsToAllTables();
+            
+            logger.info("批量添加常用字段结果:");
+            for (Map.Entry<String, DatabaseSchemaService.SchemaUpdateResult> entry : results.entrySet()) {
+                DatabaseSchemaService.SchemaUpdateResult result = entry.getValue();
+                logger.info("  字段 {}: 成功 {}/{} 个表", 
+                    entry.getKey(), 
+                    result.getSuccessCount(), 
+                    result.getTotalTables());
+            }
+        } catch (Exception e) {
+            logger.error("批量添加常用字段失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 示例5：检查字段是否存在
+     */
+    private void example5_checkFieldExists() {
+        logger.info("\n--- 示例5：检查字段是否存在 ---");
+        
+        try {
+            List<String> tableNames = databaseSchemaUtils.getAllTableNames();
+            if (!tableNames.isEmpty()) {
+                String firstTable = tableNames.get(0);
+                
+                // 检查一些常见字段
+                String[] fieldsToCheck = {"id", "created_at", "updated_at", "remark", "status"};
+                
+                logger.info("检查表 {} 的字段:", firstTable);
+                for (String fieldName : fieldsToCheck) {
+                    boolean exists = databaseSchemaUtils.columnExists(firstTable, fieldName);
+                    logger.info("  字段 {}: {}", fieldName, exists ? "存在" : "不存在");
+                }
+            }
+        } catch (Exception e) {
+            logger.error("检查字段是否存在失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 手动执行示例（通过API调用）
+     */
+    @PostMapping("/run-examples")
+    public ResponseEntity<String> runExamplesManually() {
+        try {
+            runExamples();
+            return ResponseEntity.ok("示例执行完成，请查看日志");
+        } catch (Exception e) {
+            logger.error("手动执行示例失败: {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().body("示例执行失败: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/wechatpay/service/DatabaseSchemaService.java
+++ b/src/main/java/com/example/wechatpay/service/DatabaseSchemaService.java
@@ -1,0 +1,217 @@
+package com.example.wechatpay.service;
+
+import com.example.wechatpay.util.DatabaseSchemaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * 数据库表结构管理服务类
+ * 提供批量添加字段、管理表结构等功能
+ */
+@Service
+public class DatabaseSchemaService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSchemaService.class);
+
+    @Autowired
+    private DatabaseSchemaUtils databaseSchemaUtils;
+
+    /**
+     * 为所有表添加字段
+     */
+    public SchemaUpdateResult addFieldToAllTables(String fieldName, String fieldType, boolean nullable, String defaultValue) {
+        logger.info("开始为所有表添加字段: {} {} nullable={} default={}", fieldName, fieldType, nullable, defaultValue);
+        
+        List<String> allTables = databaseSchemaUtils.getAllTableNames();
+        Map<String, Boolean> results = databaseSchemaUtils.addColumnToAllTables(fieldName, fieldType, nullable, defaultValue);
+        
+        return new SchemaUpdateResult(fieldName, allTables.size(), results);
+    }
+
+    /**
+     * 为指定表列表添加字段
+     */
+    public SchemaUpdateResult addFieldToSpecificTables(List<String> tableNames, String fieldName, String fieldType, boolean nullable, String defaultValue) {
+        logger.info("开始为指定表添加字段: {} {} nullable={} default={}, 表数量: {}", fieldName, fieldType, nullable, defaultValue, tableNames.size());
+        
+        Map<String, Boolean> results = databaseSchemaUtils.addColumnToTables(tableNames, fieldName, fieldType, nullable, defaultValue);
+        
+        return new SchemaUpdateResult(fieldName, tableNames.size(), results);
+    }
+
+    /**
+     * 为所有表添加创建时间字段
+     */
+    public SchemaUpdateResult addCreatedAtToAllTables() {
+        String databaseType = databaseSchemaUtils.getDatabaseType();
+        String columnType;
+        String defaultValue;
+        
+        if (databaseType.contains("mysql")) {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP";
+        } else if (databaseType.contains("postgresql")) {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP";
+        } else {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP";
+        }
+        
+        return addFieldToAllTables("created_at", columnType, false, defaultValue);
+    }
+
+    /**
+     * 为所有表添加更新时间字段
+     */
+    public SchemaUpdateResult addUpdatedAtToAllTables() {
+        String databaseType = databaseSchemaUtils.getDatabaseType();
+        String columnType;
+        String defaultValue;
+        
+        if (databaseType.contains("mysql")) {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP";
+        } else if (databaseType.contains("postgresql")) {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP";
+        } else {
+            columnType = "TIMESTAMP";
+            defaultValue = "CURRENT_TIMESTAMP";
+        }
+        
+        return addFieldToAllTables("updated_at", columnType, false, defaultValue);
+    }
+
+    /**
+     * 为所有表添加版本字段（用于乐观锁）
+     */
+    public SchemaUpdateResult addVersionToAllTables() {
+        return addFieldToAllTables("version", "INT", false, "0");
+    }
+
+    /**
+     * 为所有表添加软删除字段
+     */
+    public SchemaUpdateResult addSoftDeleteToAllTables() {
+        return addFieldToAllTables("deleted", "TINYINT(1)", false, "0");
+    }
+
+    /**
+     * 批量添加常用字段（创建时间、更新时间、版本、软删除）
+     */
+    public Map<String, SchemaUpdateResult> addCommonFieldsToAllTables() {
+        Map<String, SchemaUpdateResult> results = new HashMap<>();
+        
+        logger.info("开始为所有表批量添加常用字段");
+        
+        try {
+            results.put("created_at", addCreatedAtToAllTables());
+            results.put("updated_at", addUpdatedAtToAllTables());
+            results.put("version", addVersionToAllTables());
+            results.put("deleted", addSoftDeleteToAllTables());
+            
+            logger.info("批量添加常用字段完成");
+        } catch (Exception e) {
+            logger.error("批量添加常用字段失败: {}", e.getMessage(), e);
+            throw e;
+        }
+        
+        return results;
+    }
+
+    /**
+     * 获取所有表的基本信息
+     */
+    public List<TableInfo> getAllTablesInfo() {
+        List<String> tableNames = databaseSchemaUtils.getAllTableNames();
+        List<TableInfo> tablesInfo = new ArrayList<>();
+        
+        for (String tableName : tableNames) {
+            try {
+                List<DatabaseSchemaUtils.ColumnInfo> columns = databaseSchemaUtils.getTableColumns(tableName);
+                TableInfo tableInfo = new TableInfo();
+                tableInfo.setTableName(tableName);
+                tableInfo.setColumnCount(columns.size());
+                tableInfo.setColumns(columns);
+                tablesInfo.add(tableInfo);
+            } catch (Exception e) {
+                logger.error("获取表 {} 信息失败: {}", tableName, e.getMessage());
+            }
+        }
+        
+        return tablesInfo;
+    }
+
+    /**
+     * 表结构更新结果类
+     */
+    public static class SchemaUpdateResult {
+        private String fieldName;
+        private int totalTables;
+        private int successCount;
+        private int failureCount;
+        private Map<String, Boolean> tableResults;
+        private List<String> successTables;
+        private List<String> failureTables;
+
+        public SchemaUpdateResult(String fieldName, int totalTables, Map<String, Boolean> results) {
+            this.fieldName = fieldName;
+            this.totalTables = totalTables;
+            this.tableResults = results;
+            this.successTables = new ArrayList<>();
+            this.failureTables = new ArrayList<>();
+            
+            for (Map.Entry<String, Boolean> entry : results.entrySet()) {
+                if (entry.getValue()) {
+                    successTables.add(entry.getKey());
+                    successCount++;
+                } else {
+                    failureTables.add(entry.getKey());
+                    failureCount++;
+                }
+            }
+        }
+
+        // Getters
+        public String getFieldName() { return fieldName; }
+        public int getTotalTables() { return totalTables; }
+        public int getSuccessCount() { return successCount; }
+        public int getFailureCount() { return failureCount; }
+        public Map<String, Boolean> getTableResults() { return tableResults; }
+        public List<String> getSuccessTables() { return successTables; }
+        public List<String> getFailureTables() { return failureTables; }
+
+        @Override
+        public String toString() {
+            return String.format("SchemaUpdateResult{fieldName='%s', totalTables=%d, successCount=%d, failureCount=%d}",
+                    fieldName, totalTables, successCount, failureCount);
+        }
+    }
+
+    /**
+     * 表信息类
+     */
+    public static class TableInfo {
+        private String tableName;
+        private int columnCount;
+        private List<DatabaseSchemaUtils.ColumnInfo> columns;
+
+        // Getters and Setters
+        public String getTableName() { return tableName; }
+        public void setTableName(String tableName) { this.tableName = tableName; }
+        public int getColumnCount() { return columnCount; }
+        public void setColumnCount(int columnCount) { this.columnCount = columnCount; }
+        public List<DatabaseSchemaUtils.ColumnInfo> getColumns() { return columns; }
+        public void setColumns(List<DatabaseSchemaUtils.ColumnInfo> columns) { this.columns = columns; }
+
+        @Override
+        public String toString() {
+            return String.format("TableInfo{tableName='%s', columnCount=%d}", tableName, columnCount);
+        }
+    }
+}

--- a/src/main/java/com/example/wechatpay/test/DatabaseSchemaTest.java
+++ b/src/main/java/com/example/wechatpay/test/DatabaseSchemaTest.java
@@ -1,0 +1,205 @@
+package com.example.wechatpay.test;
+
+import com.example.wechatpay.service.DatabaseSchemaService;
+import com.example.wechatpay.util.DatabaseSchemaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 数据库表结构管理测试类
+ * 用于测试数据库字段添加功能
+ */
+@Component
+public class DatabaseSchemaTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSchemaTest.class);
+
+    @Autowired
+    private DatabaseSchemaService databaseSchemaService;
+
+    @Autowired
+    private DatabaseSchemaUtils databaseSchemaUtils;
+
+    /**
+     * 测试基本功能
+     */
+    public void testBasicFunctions() {
+        logger.info("=== 开始测试数据库表结构管理功能 ===");
+        
+        try {
+            // 测试1：获取所有表
+            testGetAllTables();
+            
+            // 测试2：检查字段是否存在
+            testCheckFieldExists();
+            
+            // 测试3：获取表列信息
+            testGetTableColumns();
+            
+            logger.info("=== 基本功能测试完成 ===");
+        } catch (Exception e) {
+            logger.error("基本功能测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 测试字段添加功能（谨慎使用，会修改数据库结构）
+     */
+    public void testAddFields() {
+        logger.info("=== 开始测试字段添加功能 ===");
+        logger.warn("注意：此测试会修改数据库结构，请确保在测试环境中运行！");
+        
+        try {
+            // 测试1：为所有表添加测试字段
+            testAddFieldToAllTables();
+            
+            // 测试2：为指定表添加字段
+            testAddFieldToSpecificTables();
+            
+            logger.info("=== 字段添加功能测试完成 ===");
+        } catch (Exception e) {
+            logger.error("字段添加功能测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    private void testGetAllTables() {
+        logger.info("--- 测试获取所有表 ---");
+        try {
+            List<String> tables = databaseSchemaUtils.getAllTableNames();
+            logger.info("数据库中共有 {} 个表", tables.size());
+            
+            if (tables.size() > 0 && tables.size() <= 10) {
+                logger.info("表列表: {}", tables);
+            } else if (tables.size() > 10) {
+                logger.info("前10个表: {}", tables.subList(0, 10));
+                logger.info("... 还有 {} 个表", tables.size() - 10);
+            }
+        } catch (Exception e) {
+            logger.error("获取表列表测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    private void testCheckFieldExists() {
+        logger.info("--- 测试检查字段是否存在 ---");
+        try {
+            List<String> tables = databaseSchemaUtils.getAllTableNames();
+            if (!tables.isEmpty()) {
+                String testTable = tables.get(0);
+                
+                // 测试一些常见字段
+                String[] commonFields = {"id", "name", "created_at", "updated_at", "status"};
+                
+                logger.info("检查表 {} 的字段存在性:", testTable);
+                for (String field : commonFields) {
+                    boolean exists = databaseSchemaUtils.columnExists(testTable, field);
+                    logger.info("  字段 {}: {}", field, exists ? "存在" : "不存在");
+                }
+            }
+        } catch (Exception e) {
+            logger.error("检查字段存在性测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    private void testGetTableColumns() {
+        logger.info("--- 测试获取表列信息 ---");
+        try {
+            List<String> tables = databaseSchemaUtils.getAllTableNames();
+            if (!tables.isEmpty()) {
+                String testTable = tables.get(0);
+                
+                List<DatabaseSchemaUtils.ColumnInfo> columns = databaseSchemaUtils.getTableColumns(testTable);
+                logger.info("表 {} 的列信息 (共{}列):", testTable, columns.size());
+                
+                for (DatabaseSchemaUtils.ColumnInfo column : columns) {
+                    logger.info("  {}: {} (nullable={}, default={})", 
+                        column.getColumnName(), 
+                        column.getDataType(),
+                        column.isNullable(),
+                        column.getDefaultValue());
+                }
+            }
+        } catch (Exception e) {
+            logger.error("获取表列信息测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    private void testAddFieldToAllTables() {
+        logger.info("--- 测试为所有表添加字段 ---");
+        logger.warn("这将修改数据库结构！");
+        
+        try {
+            // 添加一个测试字段
+            DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToAllTables(
+                    "test_field", 
+                    "VARCHAR(100)", 
+                    true, 
+                    "'test_default'"
+            );
+            
+            logger.info("添加字段结果: {}", result);
+            logger.info("成功: {} 个表", result.getSuccessCount());
+            logger.info("失败: {} 个表", result.getFailureCount());
+            
+            if (!result.getFailureTables().isEmpty()) {
+                logger.warn("失败的表: {}", result.getFailureTables());
+            }
+            
+        } catch (Exception e) {
+            logger.error("为所有表添加字段测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    private void testAddFieldToSpecificTables() {
+        logger.info("--- 测试为指定表添加字段 ---");
+        
+        try {
+            List<String> allTables = databaseSchemaUtils.getAllTableNames();
+            if (allTables.size() >= 2) {
+                // 选择前两个表进行测试
+                List<String> testTables = allTables.subList(0, Math.min(2, allTables.size()));
+                
+                DatabaseSchemaService.SchemaUpdateResult result = databaseSchemaService.addFieldToSpecificTables(
+                        testTables,
+                        "specific_test_field", 
+                        "INT", 
+                        false, 
+                        "0"
+                );
+                
+                logger.info("为指定表添加字段结果: {}", result);
+                logger.info("目标表: {}", testTables);
+                logger.info("成功: {} 个表", result.getSuccessCount());
+                logger.info("失败: {} 个表", result.getFailureCount());
+            } else {
+                logger.warn("数据库中表数量不足，跳过指定表测试");
+            }
+            
+        } catch (Exception e) {
+            logger.error("为指定表添加字段测试失败: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 运行所有测试（仅查询，不修改数据库）
+     */
+    public void runSafeTests() {
+        logger.info("运行安全测试（不修改数据库结构）");
+        testBasicFunctions();
+    }
+
+    /**
+     * 运行完整测试（包括修改数据库结构的测试）
+     * 警告：这会修改数据库结构！
+     */
+    public void runFullTests() {
+        logger.warn("运行完整测试（会修改数据库结构）");
+        testBasicFunctions();
+        testAddFields();
+    }
+}

--- a/src/main/java/com/example/wechatpay/util/DatabaseFieldAdder.java
+++ b/src/main/java/com/example/wechatpay/util/DatabaseFieldAdder.java
@@ -1,0 +1,291 @@
+package com.example.wechatpay.util;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * 数据库字段添加命令行工具
+ * 可以独立运行，为数据库表批量添加字段
+ */
+@Configuration
+@ComponentScan(basePackages = "com.example.wechatpay")
+public class DatabaseFieldAdder {
+
+    public static void main(String[] args) {
+        System.out.println("=== 数据库表字段添加工具 ===");
+        
+        try {
+            // 初始化Spring上下文
+            ApplicationContext context = new AnnotationConfigApplicationContext(DatabaseFieldAdder.class);
+            DatabaseSchemaUtils schemaUtils = context.getBean(DatabaseSchemaUtils.class);
+            
+            Scanner scanner = new Scanner(System.in);
+            
+            // 显示菜单
+            showMenu();
+            
+            while (true) {
+                System.out.print("\n请选择操作 (输入数字): ");
+                String choice = scanner.nextLine().trim();
+                
+                try {
+                    switch (choice) {
+                        case "1":
+                            showAllTables(schemaUtils);
+                            break;
+                        case "2":
+                            addSingleFieldToAllTables(schemaUtils, scanner);
+                            break;
+                        case "3":
+                            addCommonFieldsToAllTables(schemaUtils);
+                            break;
+                        case "4":
+                            addFieldToSpecificTables(schemaUtils, scanner);
+                            break;
+                        case "5":
+                            checkFieldExists(schemaUtils, scanner);
+                            break;
+                        case "0":
+                            System.out.println("退出程序");
+                            return;
+                        default:
+                            System.out.println("无效选择，请重新输入");
+                            showMenu();
+                    }
+                } catch (Exception e) {
+                    System.err.println("操作失败: " + e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+            
+        } catch (Exception e) {
+            System.err.println("程序启动失败: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private static void showMenu() {
+        System.out.println("\n可用操作:");
+        System.out.println("1. 查看所有表");
+        System.out.println("2. 为所有表添加单个字段");
+        System.out.println("3. 为所有表添加常用字段 (created_at, updated_at, version, deleted)");
+        System.out.println("4. 为指定表添加字段");
+        System.out.println("5. 检查字段是否存在");
+        System.out.println("0. 退出");
+    }
+
+    private static void showAllTables(DatabaseSchemaUtils schemaUtils) {
+        System.out.println("\n=== 所有表列表 ===");
+        List<String> tables = schemaUtils.getAllTableNames();
+        if (tables.isEmpty()) {
+            System.out.println("数据库中没有找到表");
+        } else {
+            System.out.println("共找到 " + tables.size() + " 个表:");
+            for (int i = 0; i < tables.size(); i++) {
+                System.out.println((i + 1) + ". " + tables.get(i));
+            }
+        }
+    }
+
+    private static void addSingleFieldToAllTables(DatabaseSchemaUtils schemaUtils, Scanner scanner) {
+        System.out.println("\n=== 为所有表添加单个字段 ===");
+        
+        System.out.print("请输入字段名: ");
+        String fieldName = scanner.nextLine().trim();
+        
+        System.out.print("请输入字段类型 (如: VARCHAR(100), INT, TIMESTAMP): ");
+        String fieldType = scanner.nextLine().trim();
+        
+        System.out.print("是否允许为空 (y/n, 默认y): ");
+        String nullableInput = scanner.nextLine().trim();
+        boolean nullable = nullableInput.isEmpty() || nullableInput.toLowerCase().startsWith("y");
+        
+        System.out.print("请输入默认值 (可为空): ");
+        String defaultValue = scanner.nextLine().trim();
+        if (defaultValue.isEmpty()) {
+            defaultValue = null;
+        }
+        
+        System.out.println("\n确认信息:");
+        System.out.println("字段名: " + fieldName);
+        System.out.println("字段类型: " + fieldType);
+        System.out.println("允许为空: " + (nullable ? "是" : "否"));
+        System.out.println("默认值: " + (defaultValue == null ? "无" : defaultValue));
+        
+        System.out.print("\n确认执行? (y/n): ");
+        String confirm = scanner.nextLine().trim();
+        
+        if (confirm.toLowerCase().startsWith("y")) {
+            List<String> tables = schemaUtils.getAllTableNames();
+            System.out.println("\n开始为 " + tables.size() + " 个表添加字段...");
+            
+            int successCount = 0;
+            int failureCount = 0;
+            
+            for (String tableName : tables) {
+                try {
+                    schemaUtils.addColumnToTable(tableName, fieldName, fieldType, nullable, defaultValue);
+                    System.out.println("✓ " + tableName + " - 成功");
+                    successCount++;
+                } catch (Exception e) {
+                    System.out.println("✗ " + tableName + " - 失败: " + e.getMessage());
+                    failureCount++;
+                }
+            }
+            
+            System.out.println("\n执行结果: 成功 " + successCount + " 个，失败 " + failureCount + " 个");
+        } else {
+            System.out.println("操作已取消");
+        }
+    }
+
+    private static void addCommonFieldsToAllTables(DatabaseSchemaUtils schemaUtils) {
+        System.out.println("\n=== 为所有表添加常用字段 ===");
+        System.out.println("将添加以下字段:");
+        System.out.println("- created_at (TIMESTAMP, NOT NULL, DEFAULT CURRENT_TIMESTAMP)");
+        System.out.println("- updated_at (TIMESTAMP, NOT NULL, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)");
+        System.out.println("- version (INT, NOT NULL, DEFAULT 0)");
+        System.out.println("- deleted (TINYINT(1), NOT NULL, DEFAULT 0)");
+        
+        Scanner scanner = new Scanner(System.in);
+        System.out.print("\n确认执行? (y/n): ");
+        String confirm = scanner.nextLine().trim();
+        
+        if (confirm.toLowerCase().startsWith("y")) {
+            List<String> tables = schemaUtils.getAllTableNames();
+            System.out.println("\n开始为 " + tables.size() + " 个表添加常用字段...");
+            
+            // 添加created_at字段
+            addFieldToAllTablesHelper(schemaUtils, "created_at", "TIMESTAMP", false, "CURRENT_TIMESTAMP");
+            
+            // 添加updated_at字段
+            String databaseType = schemaUtils.getDatabaseType();
+            String updatedAtDefault = databaseType.contains("mysql") ? 
+                "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" : "CURRENT_TIMESTAMP";
+            addFieldToAllTablesHelper(schemaUtils, "updated_at", "TIMESTAMP", false, updatedAtDefault);
+            
+            // 添加version字段
+            addFieldToAllTablesHelper(schemaUtils, "version", "INT", false, "0");
+            
+            // 添加deleted字段
+            addFieldToAllTablesHelper(schemaUtils, "deleted", "TINYINT(1)", false, "0");
+            
+            System.out.println("\n常用字段添加完成!");
+        } else {
+            System.out.println("操作已取消");
+        }
+    }
+
+    private static void addFieldToAllTablesHelper(DatabaseSchemaUtils schemaUtils, String fieldName, String fieldType, boolean nullable, String defaultValue) {
+        List<String> tables = schemaUtils.getAllTableNames();
+        int successCount = 0;
+        int failureCount = 0;
+        
+        System.out.println("\n添加字段: " + fieldName);
+        for (String tableName : tables) {
+            try {
+                schemaUtils.addColumnToTable(tableName, fieldName, fieldType, nullable, defaultValue);
+                System.out.println("  ✓ " + tableName);
+                successCount++;
+            } catch (Exception e) {
+                System.out.println("  ✗ " + tableName + " - " + e.getMessage());
+                failureCount++;
+            }
+        }
+        System.out.println("字段 " + fieldName + " 添加结果: 成功 " + successCount + " 个，失败 " + failureCount + " 个");
+    }
+
+    private static void addFieldToSpecificTables(DatabaseSchemaUtils schemaUtils, Scanner scanner) {
+        System.out.println("\n=== 为指定表添加字段 ===");
+        
+        // 显示所有表供选择
+        List<String> allTables = schemaUtils.getAllTableNames();
+        System.out.println("可用的表:");
+        for (int i = 0; i < allTables.size(); i++) {
+            System.out.println((i + 1) + ". " + allTables.get(i));
+        }
+        
+        System.out.print("\n请输入要操作的表名 (用逗号分隔): ");
+        String tableInput = scanner.nextLine().trim();
+        List<String> targetTables = Arrays.asList(tableInput.split(","));
+        
+        // 清理表名
+        targetTables.replaceAll(String::trim);
+        
+        System.out.print("请输入字段名: ");
+        String fieldName = scanner.nextLine().trim();
+        
+        System.out.print("请输入字段类型: ");
+        String fieldType = scanner.nextLine().trim();
+        
+        System.out.print("是否允许为空 (y/n, 默认y): ");
+        String nullableInput = scanner.nextLine().trim();
+        boolean nullable = nullableInput.isEmpty() || nullableInput.toLowerCase().startsWith("y");
+        
+        System.out.print("请输入默认值 (可为空): ");
+        String defaultValue = scanner.nextLine().trim();
+        if (defaultValue.isEmpty()) {
+            defaultValue = null;
+        }
+        
+        System.out.println("\n将为以下表添加字段:");
+        targetTables.forEach(table -> System.out.println("  - " + table));
+        
+        System.out.print("\n确认执行? (y/n): ");
+        String confirm = scanner.nextLine().trim();
+        
+        if (confirm.toLowerCase().startsWith("y")) {
+            int successCount = 0;
+            int failureCount = 0;
+            
+            for (String tableName : targetTables) {
+                try {
+                    schemaUtils.addColumnToTable(tableName, fieldName, fieldType, nullable, defaultValue);
+                    System.out.println("✓ " + tableName + " - 成功");
+                    successCount++;
+                } catch (Exception e) {
+                    System.out.println("✗ " + tableName + " - 失败: " + e.getMessage());
+                    failureCount++;
+                }
+            }
+            
+            System.out.println("\n执行结果: 成功 " + successCount + " 个，失败 " + failureCount + " 个");
+        } else {
+            System.out.println("操作已取消");
+        }
+    }
+
+    private static void checkFieldExists(DatabaseSchemaUtils schemaUtils, Scanner scanner) {
+        System.out.println("\n=== 检查字段是否存在 ===");
+        
+        System.out.print("请输入表名: ");
+        String tableName = scanner.nextLine().trim();
+        
+        System.out.print("请输入字段名: ");
+        String fieldName = scanner.nextLine().trim();
+        
+        try {
+            boolean exists = schemaUtils.columnExists(tableName, fieldName);
+            System.out.println("\n结果: 表 " + tableName + " 中字段 " + fieldName + " " + (exists ? "存在" : "不存在"));
+            
+            if (exists) {
+                // 显示字段详细信息
+                List<DatabaseSchemaUtils.ColumnInfo> columns = schemaUtils.getTableColumns(tableName);
+                for (DatabaseSchemaUtils.ColumnInfo column : columns) {
+                    if (column.getColumnName().equals(fieldName)) {
+                        System.out.println("字段详细信息: " + column);
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("检查失败: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/wechatpay/util/DatabaseSchemaUtils.java
+++ b/src/main/java/com/example/wechatpay/util/DatabaseSchemaUtils.java
@@ -1,0 +1,271 @@
+package com.example.wechatpay.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * 数据库表结构管理工具类
+ * 提供添加字段、查询表信息等功能
+ */
+@Component
+public class DatabaseSchemaUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSchemaUtils.class);
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatabaseSchemaUtils(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * 获取数据库中所有表名
+     */
+    public List<String> getAllTableNames() {
+        List<String> tableNames = new ArrayList<>();
+        try {
+            DatabaseMetaData metaData = jdbcTemplate.getDataSource().getConnection().getMetaData();
+            String catalog = jdbcTemplate.getDataSource().getConnection().getCatalog();
+            
+            // 获取表信息
+            ResultSet tables = metaData.getTables(catalog, null, "%", new String[]{"TABLE"});
+            while (tables.next()) {
+                String tableName = tables.getString("TABLE_NAME");
+                tableNames.add(tableName);
+            }
+            tables.close();
+        } catch (SQLException e) {
+            logger.error("获取表名失败: {}", e.getMessage(), e);
+            throw new RuntimeException("获取表名失败", e);
+        }
+        return tableNames;
+    }
+
+    /**
+     * 检查表是否存在指定字段
+     */
+    public boolean columnExists(String tableName, String columnName) {
+        try {
+            DatabaseMetaData metaData = jdbcTemplate.getDataSource().getConnection().getMetaData();
+            String catalog = jdbcTemplate.getDataSource().getConnection().getCatalog();
+            
+            ResultSet columns = metaData.getColumns(catalog, null, tableName, columnName);
+            boolean exists = columns.next();
+            columns.close();
+            return exists;
+        } catch (SQLException e) {
+            logger.error("检查字段是否存在失败: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 获取表的所有列信息
+     */
+    public List<ColumnInfo> getTableColumns(String tableName) {
+        List<ColumnInfo> columns = new ArrayList<>();
+        try {
+            DatabaseMetaData metaData = jdbcTemplate.getDataSource().getConnection().getMetaData();
+            String catalog = jdbcTemplate.getDataSource().getConnection().getCatalog();
+            
+            ResultSet rs = metaData.getColumns(catalog, null, tableName, "%");
+            while (rs.next()) {
+                ColumnInfo column = new ColumnInfo();
+                column.setColumnName(rs.getString("COLUMN_NAME"));
+                column.setDataType(rs.getString("TYPE_NAME"));
+                column.setColumnSize(rs.getInt("COLUMN_SIZE"));
+                column.setNullable(rs.getInt("NULLABLE") == DatabaseMetaData.columnNullable);
+                column.setDefaultValue(rs.getString("COLUMN_DEF"));
+                columns.add(column);
+            }
+            rs.close();
+        } catch (SQLException e) {
+            logger.error("获取表列信息失败: {}", e.getMessage(), e);
+            throw new RuntimeException("获取表列信息失败", e);
+        }
+        return columns;
+    }
+
+    /**
+     * 为单个表添加字段
+     */
+    public void addColumnToTable(String tableName, String columnName, String columnType, boolean nullable, String defaultValue) {
+        // 检查字段是否已存在
+        if (columnExists(tableName, columnName)) {
+            logger.warn("表 {} 已存在字段 {}, 跳过添加", tableName, columnName);
+            return;
+        }
+
+        StringBuilder sql = new StringBuilder();
+        sql.append("ALTER TABLE ").append(tableName)
+           .append(" ADD COLUMN ").append(columnName)
+           .append(" ").append(columnType);
+
+        if (!nullable) {
+            sql.append(" NOT NULL");
+        }
+
+        if (defaultValue != null && !defaultValue.trim().isEmpty()) {
+            sql.append(" DEFAULT ").append(defaultValue);
+        }
+
+        try {
+            jdbcTemplate.execute(sql.toString());
+            logger.info("成功为表 {} 添加字段 {} {}", tableName, columnName, columnType);
+        } catch (Exception e) {
+            logger.error("为表 {} 添加字段 {} 失败: {}", tableName, columnName, e.getMessage(), e);
+            throw new RuntimeException("添加字段失败", e);
+        }
+    }
+
+    /**
+     * 为所有表添加相同字段
+     */
+    public Map<String, Boolean> addColumnToAllTables(String columnName, String columnType, boolean nullable, String defaultValue) {
+        List<String> tableNames = getAllTableNames();
+        Map<String, Boolean> results = new HashMap<>();
+
+        logger.info("开始为 {} 个表添加字段 {}", tableNames.size(), columnName);
+
+        for (String tableName : tableNames) {
+            try {
+                addColumnToTable(tableName, columnName, columnType, nullable, defaultValue);
+                results.put(tableName, true);
+            } catch (Exception e) {
+                logger.error("为表 {} 添加字段失败: {}", tableName, e.getMessage());
+                results.put(tableName, false);
+            }
+        }
+
+        long successCount = results.values().stream().mapToLong(success -> success ? 1 : 0).sum();
+        logger.info("字段添加完成，成功: {}, 失败: {}", successCount, tableNames.size() - successCount);
+
+        return results;
+    }
+
+    /**
+     * 批量为指定表添加字段
+     */
+    public Map<String, Boolean> addColumnToTables(List<String> tableNames, String columnName, String columnType, boolean nullable, String defaultValue) {
+        Map<String, Boolean> results = new HashMap<>();
+
+        logger.info("开始为指定的 {} 个表添加字段 {}", tableNames.size(), columnName);
+
+        for (String tableName : tableNames) {
+            try {
+                addColumnToTable(tableName, columnName, columnType, nullable, defaultValue);
+                results.put(tableName, true);
+            } catch (Exception e) {
+                logger.error("为表 {} 添加字段失败: {}", tableName, e.getMessage());
+                results.put(tableName, false);
+            }
+        }
+
+        long successCount = results.values().stream().mapToLong(success -> success ? 1 : 0).sum();
+        logger.info("字段添加完成，成功: {}, 失败: {}", successCount, tableNames.size() - successCount);
+
+        return results;
+    }
+
+    /**
+     * 删除表中的字段
+     */
+    public void dropColumnFromTable(String tableName, String columnName) {
+        if (!columnExists(tableName, columnName)) {
+            logger.warn("表 {} 不存在字段 {}, 跳过删除", tableName, columnName);
+            return;
+        }
+
+        String sql = "ALTER TABLE " + tableName + " DROP COLUMN " + columnName;
+        try {
+            jdbcTemplate.execute(sql);
+            logger.info("成功从表 {} 删除字段 {}", tableName, columnName);
+        } catch (Exception e) {
+            logger.error("从表 {} 删除字段 {} 失败: {}", tableName, columnName, e.getMessage(), e);
+            throw new RuntimeException("删除字段失败", e);
+        }
+    }
+
+    /**
+     * 获取数据库类型
+     */
+    public String getDatabaseType() {
+        try {
+            DatabaseMetaData metaData = jdbcTemplate.getDataSource().getConnection().getMetaData();
+            return metaData.getDatabaseProductName().toLowerCase();
+        } catch (SQLException e) {
+            logger.error("获取数据库类型失败: {}", e.getMessage(), e);
+            return "unknown";
+        }
+    }
+
+    /**
+     * 列信息类
+     */
+    public static class ColumnInfo {
+        private String columnName;
+        private String dataType;
+        private int columnSize;
+        private boolean nullable;
+        private String defaultValue;
+
+        // Getters and Setters
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public void setColumnName(String columnName) {
+            this.columnName = columnName;
+        }
+
+        public String getDataType() {
+            return dataType;
+        }
+
+        public void setDataType(String dataType) {
+            this.dataType = dataType;
+        }
+
+        public int getColumnSize() {
+            return columnSize;
+        }
+
+        public void setColumnSize(int columnSize) {
+            this.columnSize = columnSize;
+        }
+
+        public boolean isNullable() {
+            return nullable;
+        }
+
+        public void setNullable(boolean nullable) {
+            this.nullable = nullable;
+        }
+
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public String toString() {
+            return "ColumnInfo{" +
+                    "columnName='" + columnName + '\'' +
+                    ", dataType='" + dataType + '\'' +
+                    ", columnSize=" + columnSize +
+                    ", nullable=" + nullable +
+                    ", defaultValue='" + defaultValue + '\'' +
+                    '}';
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,28 @@ server:
 spring:
   application:
     name: wechat-pay-demo
+  
+  # 数据库配置
+  datasource:
+    # MySQL配置示例
+    url: jdbc:mysql://localhost:3306/your_database?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai
+    username: your_username
+    password: your_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    
+    # PostgreSQL配置示例（注释掉，根据需要选择）
+    # url: jdbc:postgresql://localhost:5432/your_database
+    # username: your_username
+    # password: your_password
+    # driver-class-name: org.postgresql.Driver
+    
+    # 连接池配置
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
 # 微信支付配置
 wechat:


### PR DESCRIPTION
Introduce a Java-based database schema management tool to enable adding fields to tables via API or CLI.

The project initially lacked database configuration. This PR sets up database connectivity and provides a robust solution for bulk adding fields to tables, including common audit fields, with support for MySQL and PostgreSQL.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5f1511-19b8-47d7-bd92-498ca0ebdc55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f5f1511-19b8-47d7-bd92-498ca0ebdc55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

